### PR TITLE
Convert step files to Raspberry Flavoured Markdown

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,39 +1,17 @@
-<h2 class="c-project-heading--task">Draw a line</h2>
+## Draw a line
 
-## Step 1
+Change the number in the line `turtle.forward(200)`.
 
-Click **Run** to see the length of a 200 line.
-
-
-Change the number in the line `turtle.forward(200)`
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 5
----
+```python filename="main.py" line_numbers="true" line_highlights="5"
 from turtle import Turtle
 
 turtle = Turtle()
 
-turtle.forward(100)
---- /code ---
-</div>
-
-## Step 2
-
-Click **Run** to see your new changes.
-
-
-<div class="c-project-output">
-
-![A path formed by a line to the right.](images/line.png)
-</div>
+turtle.forward(200)
+```
 
 ## Now run your code
 
 Click **Run** and check that the turtle draws a straight line to the right.
+
+![A path formed by a line to the right.](images/line.png)

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,20 +1,10 @@
-<h2 class="c-project-heading--task">Turning</h2>
+## Turning
 
 Make the turtle turn around.
 
-## Step 1
+To turn the turtle, it has to move forward and turn right (or left).
 
-To turn the turtle, it has to move forward and turn right (or left). 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 6-7
----
+```python filename="main.py" line_numbers="true" line_highlights="6-7"
 from turtle import Turtle
 
 turtle = Turtle()
@@ -22,28 +12,15 @@ turtle = Turtle()
 turtle.forward(100)
 turtle.right(90)
 turtle.forward(60)
---- /code ---
-</div>
+```
 
-## Step 2
-
-Click **Run** to see your new changes.
-
-
-<div class="c-project-output">
-
-![A path formed by a line to the right, then angled downwards](images/turn.png)
-</div>
-
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- `turtle.right(90)` turns the cursor 90 degrees right. 
-- `turtle.left(90)` turns the cursor 90 degrees left.
-
-</div>
+> [!TIP]
+>
+> - `turtle.right(90)` turns the cursor 90 degrees right.
+> - `turtle.left(90)` turns the cursor 90 degrees left.
 
 ## Now run your code
 
 Click **Run** and check that the line turns and then carries on drawing in the new direction.
+
+![A path formed by a line to the right, then angled downwards](images/turn.png)

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -1,20 +1,10 @@
-<h2 class="c-project-heading--task">Draw a rectangle</h2>
-
-## Step 1
+## Draw a rectangle
 
 All angles are right angles (90 degrees).
 
 Add a loop that repeats the path twice to complete the rectangle.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 5-9
----
+```python filename="main.py" line_numbers="true" line_highlights="5-9"
 from turtle import Turtle
 
 turtle = Turtle()
@@ -25,25 +15,21 @@ for i in range(2):
     turtle.forward(60)
     turtle.right(90)
 
---- /code ---
+```
 
-</div>
-
-<div class="c-project-output">
-
-![A path forming a rectangle](images/rectangle.png)
-</div>
-
-## Step 2
-
-### Experiment
-Try to draw all of these shapes, to become a true shape master:
-
-- A square (all sides the same length)
-- A triangle (how many degrees do you need to turn?)
-- A cross (`backward` and `forward` work well together)
-- A circle (what happens if you turn a small amount lots of times, and move forward a tiny bit each time?)
+> [!CHALLENGE]
+>
+> ## Experiment
+>
+> Try to draw all of these shapes, to become a true shape master:
+>
+> - A square (all sides the same length)
+> - A triangle (how many degrees do you need to turn?)
+> - A cross (`backward` and `forward` work well together)
+> - A circle (what happens if you turn a small amount lots of times, and move forward a tiny bit each time?)
 
 ## Now run your code
 
 Click **Run** and check that the turtle draws your shape correctly.
+
+![A path forming a rectangle](images/rectangle.png)

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,22 +1,12 @@
-<h2 class="c-project-heading--task">Speedy colour!</h2>
+## Speedy colour!
 
 Give your shape a bright blue pen colour and speed the turtle up!
-
-## Step 1
 
 Add R, G, and B values, then change the `color` attribute.
 
 Set the speed attribute to `0`, which removes any animation delay.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 5-8, 10
----
+```python filename="main.py" line_numbers="true" line_highlights="5-8,10"
 from turtle import Turtle
 
 turtle = Turtle()
@@ -33,32 +23,24 @@ for i in range(2):
     turtle.right(90)
     turtle.forward(60)
     turtle.right(90)
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
+> [!TIP]
+>
+> - **RGB values** are used to pick colours
+> - RGB stands for **Red**, **Green**, and **Blue**
+> - Each can be set from `0` (none) to `255` (full)
+> - We have used a rectangle as the example so you can see how each new concept works
+> - If you made a different shape in earlier steps, that’s fine — just apply the same ideas to your own shape!
 
-![A blue rectangle](images/rectangle_blue.png)
-</div>
-
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- **RGB values** are used to pick colours 
-- RGB stands for **Red**, **Green**, and **Blue**
-- Each can be set from `0` (none) to `255` (full) 
-- We have used a rectangle as the example so you can see how each new concept works  
-- If you made a different shape in earlier steps, that’s fine — just apply the same ideas to your own shape! 
-
-</div>
-
-## Step 2
-
-### Experiment
-
-- Change the pen colour to your favourite colour.
+> [!CHALLENGE]
+>
+> ## Experiment
+>
+> - Change the pen colour to your favourite colour.
 
 ## Now run your code
 
 Click **Run** and check that the turtle draws your shape in the pen colour you chose.
+
+![A blue rectangle](images/rectangle_blue.png)

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,20 +1,10 @@
-<h2 class="c-project-heading--task">Draw a spiral of shapes</h2>
+## Draw a spiral of shapes
 
 Use loops to create a repeated pattern.
 
-## Step 1
-
 Add an outer loop and a small turn after each rectangle.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 12-18
----
+```python filename="main.py" line_numbers="true" line_highlights="12-18"
 from turtle import Turtle
 
 turtle = Turtle()
@@ -33,28 +23,15 @@ for j in range(36):
         turtle.forward(60)
         turtle.right(90)
     turtle.right(10)
---- /code ---
-</div>
+```
 
-## Step 2
-
-Run your code. Your shape should be repeated 36 times, with each one rotated 10° to make a spiral.
-
-
-<div class="c-project-output">
-
-![A blue spiral formed of 36 rotated rectangles.](images/spiral.png)
-</div>
-
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-- The outer loop will draw your shape many times, turning a little after each one
-- Rotating 10° each loop: 360 ÷ 10 = 36 steps
-
-</div>
+> [!TIP]
+>
+> - The outer loop will draw your shape many times, turning a little after each one
+> - Rotating 10° each loop: 360 ÷ 10 = 36 steps
 
 ## Now run your code
 
 Run your code and check that your 36 shapes make a spiral.
+
+![A blue spiral formed of 36 rotated rectangles.](images/spiral.png)

--- a/en/step_6.md
+++ b/en/step_6.md
@@ -1,20 +1,10 @@
-<h2 class="c-project-heading--task">Multi-colour spiral</h2>
+## Multi-colour spiral
 
 Draw the spiral again with each rectangle in a **different colour**.
 
-## Step 1
-
 Move the `turtle.color` function inside the inner loop, so the spiral shifts colour each time your shape is drawn.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 8, 17-20
----
+```python filename="main.py" line_numbers="true" line_highlights="8,17-20"
 from turtle import Turtle
 
 turtle = Turtle()
@@ -36,31 +26,18 @@ for j in range(36):
         B = (B - 3) % 256
         turtle.color((R/255, G/255, B/255))
     turtle.right(10)
---- /code ---
-</div>
+```
 
-## Step 2
-
-Run your code to see your changes.
-
-
-<div class="c-project-output">
-
-![A multi-coloured spiral](images/spiral_colours.png)
-</div>
-
-## Step 3
-
-### Experiment
-
-<div class="c-project-callout c-project-callout--tip">
-
-- Try different numbers for `R`, `G`, and `B` to see new colour blends
-- To change the colour slowly, use small numbers like `+1` or `-1`
-- To make the colour shift faster, add or subtract larger numbers from `R`, `G`, or `B`
-  
-</div>
+> [!CHALLENGE]
+>
+> ## Experiment
+>
+> - Try different numbers for `R`, `G`, and `B` to see new colour blends
+> - To change the colour slowly, use small numbers like `+1` or `-1`
+> - To make the colour shift faster, add or subtract larger numbers from `R`, `G`, or `B`
 
 ## Now run your code
 
 Run your code and check that the spiral now changes through different colours.
+
+![A multi-coloured spiral](images/spiral_colours.png)

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -1,22 +1,12 @@
-<h2 class="c-project-heading--task">Challenge: Tighter turns</h2>
+## Challenge: Tighter turns
 
 Change the **amount** the cursor turns, based on the number of shapes you want in the spiral.
-
-## Step 1
 
 Add a new variable called `number_of_shapes`.
 
 Then use the variable as the number of shapes to draw and to calculate the angle to turn after each shape is drawn.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 9
-line_highlights: 11, 13, 23
----
+```python filename="main.py" line_numbers="true" line_number_start="9" line_highlights="11,13,23"
 turtle.speed(0)
 
 number_of_shapes = 80
@@ -32,20 +22,16 @@ for j in range(number_of_shapes):
         B = (B - 3) % 256
         turtle.color((R/255, G/255, B/255))
     turtle.right(360/number_of_shapes)
---- /code ---
-</div>
+```
 
-<div class="c-project-output">
-
-![A multi-coloured spiral made up of more shapes and colours](images/80_shapes.png)
-</div>
-
-## Step 2
-
-### Experiment
-
-Try changing the value of the new variable.
+> [!CHALLENGE]
+>
+> ## Experiment
+>
+> Try changing the value of the new variable.
 
 ## Now run your code
 
 Run your code and check that the spiral now has more shapes and more colour changes.
+
+![A multi-coloured spiral made up of more shapes and colours](images/80_shapes.png)


### PR DESCRIPTION
Converts all step files to Raspberry Flavoured Markdown (RPF): task headings → `##`, code blocks → fenced blocks with inline attributes, tips → `> [!TIP]`, experiment extensions → `> [!CHALLENGE]`, output wrappers dropped to bare images.

Copy/code fixes agreed with the team:
- step_1: the code block showed `turtle.forward(100)` but the starter code and the instruction use `forward(200)`; corrected the code block to `forward(200)`. Also removed the broken 'see the length of a 200 line' run lead-in.
- steps 1, 2, 5, 6: removed run lead-ins that duplicated the final run-check under **Now run your code**.

`listed: true` preserved (stays published).